### PR TITLE
Update sec. 4.3.3 of section_wl_gal-clusters.tex

### DIFF
--- a/section_wl_gal-clusters.tex
+++ b/section_wl_gal-clusters.tex
@@ -838,7 +838,9 @@ changes the electric field geometry and new charges generated are more likely to
 be deflected into neighboring pixels. This has the effect of making bright stars
 appear larger than faint stars, as the repulsion effect is non-linear and
 increases with signal level. The field geometry is very different in a NIR
-detector, but a brighter-fatter effect is still possible.
+detector, but a brighter-fatter effect is still possible. \cite{2017JInst..12C4009P} 
+and \cite{2017arXiv171206642P} report a first detection of the BFE in NIR 
+detectors (H1RG and H2RG) using on-sky and laboratory data, respectively. 
 
 We have searched for the brighter-fatter effect in the H4RG detector arrays
 using the flat fields for two devices H4RG-17940 and H4RG-18237, provided to us


### PR DESCRIPTION
Added the following sentence in section 4.3.3 regarding the detection of the BFE in NIR detectors 
with on-sky and laboratory data: 
"\cite{2017JInst..12C4009P} 
and \cite{2017arXiv171206642P} report a first detection of the BFE in NIR 
detectors (H1RG and H2RG) using on-sky and laboratory data, respectively. "